### PR TITLE
fix: Age calculation accounts 6 extra years hours

### DIFF
--- a/backend/src/app/models/Student.js
+++ b/backend/src/app/models/Student.js
@@ -1,6 +1,5 @@
 import Sequelize, { Model } from 'sequelize';
-import { formatDistanceStrict } from 'date-fns';
-import pt from 'date-fns/locale/pt';
+import { differenceInCalendarDays } from 'date-fns';
 
 class Student extends Model {
   static init(sequelize) {
@@ -12,9 +11,7 @@ class Student extends Model {
         age: {
           type: Sequelize.VIRTUAL,
           get() {
-            return formatDistanceStrict(this.birth, new Date(), {
-              locale: pt,
-            });
+            return this.calculateAge();
           },
         },
         weight: Sequelize.DECIMAL,
@@ -24,6 +21,13 @@ class Student extends Model {
     );
 
     return this;
+  }
+
+  calculateAge() {
+    const age = Math.floor(
+      differenceInCalendarDays(new Date(), this.birth) / 365.25
+    );
+    return `${age} anos`;
   }
 }
 


### PR DESCRIPTION
I've noticed that the age calculation does not account for the extra 6 hours we have in the year.
ie: if the birth date of student is 1971-10-20 and today date is 2019-10-21 it should return 47 anos, but it returns 48 anos, instead.