### PR TITLE
refact: Add one more validation to auth JWT middleware

### DIFF
--- a/backend/src/app/middlewares/auth.js
+++ b/backend/src/app/middlewares/auth.js
@@ -10,7 +10,11 @@ export default async (req, res, next) => {
     return res.status(401).json({ error: 'Token not provided' });
   }
 
-  const [, token] = authHeader.split(' ');
+  const [bearer, token] = authHeader.split(' ');
+
+  if (bearer !== 'Bearer') {
+    return response.status(401).json({ error: 'Token malformed' });
+  }
 
   try {
     const decoded = await promisify(jwt.verify)(token, authConfig.secret);


### PR DESCRIPTION
Put a verification in the auth middleware to validate the format `Bearer {token}`.
This fix a problem to accept a validation of a user that send just ` {token}` or `blabla {token}` as authentication.