### PR TITLE
refact: Add unique constraint to enrollment table

### DIFF
--- a/backend/src/database/migrations/20191020175740-create-enrollments.js
+++ b/backend/src/database/migrations/20191020175740-create-enrollments.js
@@ -10,6 +10,7 @@ module.exports = {
       student_id: {
         type: Sequelize.INTEGER,
         allowNull: false,
+        unique: true,
         references: {
           model: 'students',
           key: 'id',


### PR DESCRIPTION
Add a prop unique to the `student_id` column in the enrollments table.
The reason is add one more level of validation to the table. This way, there isn't any possibility to save two equals users in the table.